### PR TITLE
Update to new wiki URL

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -9,7 +9,7 @@ const NodeHelper = require("node_helper")
 const path = require("path")
 const fs = require("fs")
 const https = require("https")
-const repository = "https://github.com/MichMich/MagicMirror/wiki/MagicMirror%C2%B2-Modules"
+const repository = "https://github.com/MichMich/MagicMirror/wiki/3rd-Party-Modules"
 const moduleJson = "modules.json"
 
 module.exports = NodeHelper.create({


### PR DESCRIPTION
I noticed that the Remote Control module still had very limited listings, which seemed odd given this add-on! Turns out the URL on the wiki changed to [this](https://github.com/MichMich/MagicMirror/wiki/3rd-Party-Modules) which broke the functionality. Changed it locally and -BOOM!- all good again. Thanks for the idea in the first place.